### PR TITLE
Upgrade di sicurezza della libreria Crypto.js from 3.19-1 to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3341,9 +3341,9 @@
       }
     },
     "crypto-js": {
-      "version": "3.1.9-1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.2.1.tgz",
+      "integrity": "sha512-fIEXOyiXnmPbPk2+q8t97VYDSo8naqvI+2v0AJeLraQzhuL/GZ2qgcRpEadVQ7r8pXwBOHVjwOdyAXYYb3DWiQ=="
     },
     "css-color-names": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "axios": "^0.19.0",
     "babel-runtime": "^6.26.0",
     "core-js": "^2.6.5",
-    "crypto-js": "^3.1.9-1",
+    "crypto-js": "^3.2.1",
     "materialize-css": "^1.0.0-rc.2",
     "vue": "^2.6.10",
     "vue-pdf": "^4.0.7",


### PR DESCRIPTION
Le vecchie librerie Crypto.js sono vulnerabili all'Insecure Randomness. Il metodo `secureRandom()` dovrebbe restituire una stringa di dati pseudo-casuale crittograficamente forte, ma è polarizzata a determinate cifre. Un utente malintenzionato potrebbe essere in grado di indovinare le cifre create.